### PR TITLE
Resolving MySQL ID Jump and Inactive Question Selection Issues

### DIFF
--- a/backend_spring/src/main/java/com/example/project_orion/controller/QuestionController.java
+++ b/backend_spring/src/main/java/com/example/project_orion/controller/QuestionController.java
@@ -28,12 +28,10 @@ public class QuestionController {
             @RequestParam(name = "pageNumber", defaultValue = AppConstants.PAGE_NUMBER, required = false) Integer pageNumber,
             @RequestParam(name = "pageSize", defaultValue = AppConstants.PAGE_SIZE, required = false) Integer pageSize,
             @RequestParam(name = "sortBy", defaultValue = AppConstants.SORT_QUESTIONS_BY, required = false) String sortBy,
-            @RequestParam(name = "sortOrder", defaultValue = AppConstants.SORT_DIR, required = false) String sortOrder
-    ){
-        /*
-        TODO: API crashing if the pagination details were wrong
-        */
-        QuestionResponse questionResponse = questionService.getAllQuestions(pageNumber, pageSize, sortBy, sortOrder);
+            @RequestParam(name = "sortOrder", defaultValue = AppConstants.SORT_DIR, required = false) String sortOrder,
+            @RequestParam(name = "userType", defaultValue = "public", required = false) String userType
+    ) {
+        QuestionResponse questionResponse = questionService.fetchAllQuestions(new Filter(), pageNumber, pageSize, sortBy, sortOrder, userType);
         return new ResponseEntity<>(questionResponse, HttpStatus.OK);
     }
 
@@ -70,9 +68,12 @@ public class QuestionController {
             @RequestParam(name = "pageNumber", defaultValue = AppConstants.PAGE_NUMBER, required = false) Integer pageNumber,
             @RequestParam(name = "pageSize", defaultValue = AppConstants.PAGE_SIZE, required = false) Integer pageSize,
             @RequestParam(name = "sortBy", defaultValue = AppConstants.SORT_QUESTIONS_BY, required = false) String sortBy,
-            @RequestParam(name = "sortOrder", defaultValue = AppConstants.SORT_DIR, required = false) String sortOrder
-            ) {
-        QuestionResponse questions = questionService.fetchAllQuestions(filter, pageNumber, pageSize, sortBy, sortOrder);
+            @RequestParam(name = "sortOrder", defaultValue = AppConstants.SORT_DIR, required = false) String sortOrder,
+            @RequestParam(name = "userType", required = true) String userType
+    ) {
+        QuestionResponse questions = questionService.fetchAllQuestions(filter, pageNumber, pageSize, sortBy, sortOrder, userType);
         return new ResponseEntity<>(questions, HttpStatus.OK);
     }
 }
+
+

--- a/backend_spring/src/main/java/com/example/project_orion/models/Question.java
+++ b/backend_spring/src/main/java/com/example/project_orion/models/Question.java
@@ -3,33 +3,17 @@ package com.example.project_orion.models;
 import com.example.project_orion.enums.Difficulty;
 import com.example.project_orion.enums.Status;
 import com.example.project_orion.enums.Subject;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.example.project_orion.service.QuestionIdGeneratorService;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.Set;
-
-/*
-// @Data
-WARNING :: don't use @Data , use @Getter & @Setter
-IF YOU WANT TO USE THE @Data then Override the @hashCode function,
-inorder to avoid the stackoverflow in case of many-to-many relationships
-
-The error happens because the hash code calculation recursively calls the
-hashCode() method on entities like collections (HashSet, List, etc.) within the entity itself,
-causing infinite recursion.
-
-Overriding of the hasCode function
-    @Override
-    public int hashCode(){
-        return Objects.hash(questionId);
-    }
-* */
 
 @Entity
 @Getter
@@ -41,7 +25,6 @@ Overriding of the hasCode function
 public class Question {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long questionId;
 
     @NotBlank
@@ -84,4 +67,15 @@ public class Question {
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
     private Set<Tag> tagList;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.questionId == null) {
+            this.questionId = questionIdGeneratorService.generateNextId();
+        }
+    }
+
+    @Transient
+    @Autowired
+    private QuestionIdGeneratorService questionIdGeneratorService;
 }

--- a/backend_spring/src/main/java/com/example/project_orion/models/Question.java
+++ b/backend_spring/src/main/java/com/example/project_orion/models/Question.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.lang.NonNull;
 
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 @Table(name = "questions")
+@Configurable
 public class Question {
 
     @Id
@@ -68,14 +70,14 @@ public class Question {
     )
     private Set<Tag> tagList;
 
+    @Transient
+    @Autowired
+    private QuestionIdGeneratorService questionIdGeneratorService;
+
     @PrePersist
     public void prePersist() {
         if (this.questionId == null) {
             this.questionId = questionIdGeneratorService.generateNextId();
         }
     }
-
-    @Transient
-    @Autowired
-    private QuestionIdGeneratorService questionIdGeneratorService;
 }

--- a/backend_spring/src/main/java/com/example/project_orion/repository/QuestionRepository.java
+++ b/backend_spring/src/main/java/com/example/project_orion/repository/QuestionRepository.java
@@ -12,16 +12,20 @@ import java.util.List;
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Question findByTitle(@NotBlank @Size(min = 3, max = 50, message = "must contain at-least 3 characters & at-max 25 characters") String title);
 
+    @Query("SELECT MAX(q.questionId) FROM Question q")
+    Long findMaxId();
 
     @Query(value = "SELECT * FROM questions q " +
             "WHERE (:title = '' OR q.title LIKE CONCAT('%', :title, '%')) " +
             "AND (:subject IS NULL OR q.subject = :subject) " +
-            "AND (:difficulty IS NULL OR q.difficulty = :difficulty)",
+            "AND (:difficulty IS NULL OR q.difficulty = :difficulty) " +
+            "AND (:status IS NULL OR q.status = :status)",
             nativeQuery = true)
     List<Question> findQuestions(
             @Param("title") String title,
             @Param("subject") String subject,
-            @Param("difficulty") String difficulty);
+            @Param("difficulty") String difficulty,
+            @Param("status") String status);
 
     @Query(value = "SELECT DISTINCT q.* FROM questions q " +
             "JOIN question_tags qt ON q.question_id = qt.question_id " +
@@ -35,19 +39,14 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             "    WHERE qt_inner.tag_id IN (:tagIds) " +
             "    GROUP BY qt_inner.question_id " +
             "    HAVING COUNT(DISTINCT qt_inner.tag_id) = :tagCount " +
-            "))",
+            ")) " +
+            "AND (:status IS NULL OR q.status = :status)",
             nativeQuery = true)
     List<Question> findQuestionsWithTags(
             @Param("title") String title,
             @Param("subject") String subject,
             @Param("difficulty") String difficulty,
             @Param("tagIds") List<Long> tagIds,
-            @Param("tagCount") Integer tagCount);
-
+            @Param("tagCount") Integer tagCount,
+            @Param("status") String status);
 }
-
-
-/*
-* ONLY CLASS NAME NOT TABLE NAME DIRECTLY
-* CASE sensitive
-* */

--- a/backend_spring/src/main/java/com/example/project_orion/service/QuestionIdGeneratorService.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/QuestionIdGeneratorService.java
@@ -1,17 +1,6 @@
+// File: src/main/java/com/example/project_orion/service/QuestionIdGeneratorService.java
 package com.example.project_orion.service;
 
-import com.example.project_orion.repository.QuestionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-@Service
-public class QuestionIdGeneratorService {
-
-    @Autowired
-    private QuestionRepository questionRepository;
-
-    public synchronized Long generateNextId() {
-        Long lastId = questionRepository.findMaxId();
-        return (lastId != null) ? lastId + 1 : 1L;
-    }
+public interface QuestionIdGeneratorService {
+    Long generateNextId();
 }

--- a/backend_spring/src/main/java/com/example/project_orion/service/QuestionIdGeneratorService.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/QuestionIdGeneratorService.java
@@ -1,0 +1,17 @@
+package com.example.project_orion.service;
+
+import com.example.project_orion.repository.QuestionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionIdGeneratorService {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    public synchronized Long generateNextId() {
+        Long lastId = questionRepository.findMaxId();
+        return (lastId != null) ? lastId + 1 : 1L;
+    }
+}

--- a/backend_spring/src/main/java/com/example/project_orion/service/QuestionService.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/QuestionService.java
@@ -16,6 +16,5 @@ public interface QuestionService {
 
     QuestionDTO deleteQuestion(@Valid Long questionId);
 
-    QuestionResponse fetchAllQuestions(Filter filter, Integer pageNumber, Integer pageSize, String sortBy, String sortOrder);
-
+    QuestionResponse fetchAllQuestions(Filter filter, Integer pageNumber, Integer pageSize, String sortBy, String sortOrder, String userType);
 }

--- a/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionIdGeneratorServiceImpl.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionIdGeneratorServiceImpl.java
@@ -1,0 +1,19 @@
+package com.example.project_orion.service.impl;
+
+import com.example.project_orion.repository.QuestionRepository;
+import com.example.project_orion.service.QuestionIdGeneratorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionIdGeneratorServiceImpl implements QuestionIdGeneratorService {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Override
+    public synchronized Long generateNextId() {
+        Long lastId = questionRepository.findMaxId();
+        return (lastId != null) ? lastId + 1 : 1L;
+    }
+}

--- a/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionServiceImpl.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionServiceImpl.java
@@ -6,7 +6,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.example.project_orion.enums.Status;
 import com.example.project_orion.service.QuestionService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,11 +42,8 @@ public class QuestionServiceImpl implements QuestionService {
     @Autowired
     private ModelMapper modelMapper;
 
-//    private final List<Question> questionList = new ArrayList<>();
-
     @Override
     public QuestionResponse getAllQuestions(Integer pageNumber, Integer pageSize, String sortBy, String sortOrder) {
-
         Sort sortByAndOrder = sortOrder.equalsIgnoreCase("asc")
                 ? Sort.by(sortBy).ascending()
                 : Sort.by(sortBy).descending();
@@ -66,11 +65,20 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
-    public QuestionDTO createQuestion(String authorName, QuestionDTO questionDTO) {
+    public QuestionDTO deleteQuestion(Long questionId) {
+        Question questionFromDB = questionRepository.findById(questionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Question", "questionId", questionId));
 
+        questionRepository.delete(questionFromDB);
+
+        return modelMapper.map(questionFromDB, QuestionDTO.class);
+    }
+
+    @Override
+    public QuestionDTO createQuestion(String authorName, QuestionDTO questionDTO) {
         Question questionFromDB = questionRepository.findByTitle(questionDTO.getTitle());
 
-        if(questionFromDB != null){
+        if (questionFromDB != null) {
             throw new APIException("Question with title " + questionDTO.getTitle() + " already exists!!!");
         }
 
@@ -95,7 +103,6 @@ public class QuestionServiceImpl implements QuestionService {
             Set<Tag> tags = new HashSet<>();
             for (Tag tag : question.getTagList()) {
                 Tag existingTag = tagRepository.findByText(tag.getText());
-                // Save new tag if it doesn't exist
                 tags.add(Objects.requireNonNullElseGet(existingTag, () -> tagRepository.save(tag)));
             }
             question.setTagList(tags);
@@ -106,7 +113,6 @@ public class QuestionServiceImpl implements QuestionService {
         List<Option> options = savedQuestion.getOptions();
         Long correctOptionId = options.get(questionDTO.getCorrectOptionId() - 1).getOptionId();
 
-        // Create an Answer and set the correct option
         Answer answer = new Answer();
         answer.setCorrectOptionId(correctOptionId);
         savedQuestion.setAnswer(answer);
@@ -125,23 +131,15 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionDTO updateQuestion(Long questionId, QuestionDTO questionDTO) {
-
         Question questionFromDB = questionRepository.findById(questionId)
                 .orElseThrow(() -> new APIException("Question with id " + questionId + " not found!"));
 
-        // Only update fields that are provided in the DTO
         if (questionDTO.getTitle() != null) {
             questionFromDB.setTitle(questionDTO.getTitle());
         }
         if (questionDTO.getDescription() != null) {
             questionFromDB.setDescription(questionDTO.getDescription());
         }
-        /*
-            don't update the author, it will be fixed once it is set
-            if (questionDTO.getAuthor() != null) {
-                questionFromDB.setAuthor(questionDTO.getAuthor());
-            }
-        */
         if (questionDTO.getSubject() != null) {
             questionFromDB.setSubject(questionDTO.getSubject());
         }
@@ -151,10 +149,9 @@ public class QuestionServiceImpl implements QuestionService {
         if (questionDTO.getOptions() != null) {
             List<Option> newOptionList = questionDTO.getOptions();
             List<Option> originalOptionList = questionFromDB.getOptions();
-            for(int idx = 0; idx < newOptionList.size(); idx++){
+            for (int idx = 0; idx < newOptionList.size(); idx++) {
                 originalOptionList.get(idx).setText(newOptionList.get(idx).getText());
             }
-          // questionFromDB.setOptions(originalOptionList); redundant update
         }
         if (questionDTO.getTagList() != null) {
             Set<Tag> tags = new HashSet<>();
@@ -164,7 +161,7 @@ public class QuestionServiceImpl implements QuestionService {
             }
             questionFromDB.setTagList(tags);
         }
-        if(questionDTO.getStatus() != null){
+        if (questionDTO.getStatus() != null) {
             questionFromDB.setStatus(questionDTO.getStatus());
         }
         Question updatedQuestion = questionRepository.save(questionFromDB);
@@ -183,40 +180,28 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
-    public QuestionDTO deleteQuestion(Long questionId) {
-        Question questionFromDB = questionRepository.findById(questionId)
-                .orElseThrow(() -> new APIException("Question with id " + questionId + " not found!"));
-
-        QuestionDTO questionDTO = modelMapper.map(questionFromDB, QuestionDTO.class);
-        questionRepository.delete(questionFromDB);
-        return questionDTO;
-    }
-
-    @Override
-    public QuestionResponse fetchAllQuestions(Filter filter, Integer pageNumber, Integer pageSize, String sortBy, String sortOrder) {
-        /*
-            TODO: inactive questions are getting selected
-             if admin -> then active and inactive
-             if public -> then active only
-        */
-        if(filter.isEmpty()){
-            return getAllQuestions(pageNumber, pageSize, sortBy, sortOrder);
-        }
-
-        String subjectValue = (filter.getSubject() != null) ? filter.getSubject().toString() : null;
-        String difficultyValue = (filter.getDifficulty() != null) ? filter.getDifficulty().toString() : null;
-        Integer tagCount = (filter.getTagList() != null) ? filter.getTagList().size() : null;
+    public QuestionResponse fetchAllQuestions(Filter filter, Integer pageNumber, Integer pageSize, String sortBy, String sortOrder, String userType) {
+        String status = "public".equalsIgnoreCase(userType) ? Status.ACTIVE.name() : null;
 
         List<Question> questionList;
-        if(filter.getTagList() == null){
-            questionList = questionRepository.findQuestions(filter.getTitle(), subjectValue, difficultyValue);
-        }else{
-            questionList = questionRepository.findQuestionsWithTags(filter.getTitle(),
-                    subjectValue,
-                    difficultyValue,
-                    filter.getTagList(),
-                    tagCount
-            );
+        if (filter.isEmpty()) {
+            questionList = questionRepository.findQuestions("", null, null, status);
+        } else {
+            String subjectValue = (filter.getSubject() != null) ? filter.getSubject().toString() : null;
+            String difficultyValue = (filter.getDifficulty() != null) ? filter.getDifficulty().toString() : null;
+            Integer tagCount = (filter.getTagList() != null) ? filter.getTagList().size() : null;
+
+            if (filter.getTagList() == null) {
+                questionList = questionRepository.findQuestions(filter.getTitle(), subjectValue, difficultyValue, status);
+            } else {
+                questionList = questionRepository.findQuestionsWithTags(filter.getTitle(),
+                        subjectValue,
+                        difficultyValue,
+                        filter.getTagList(),
+                        tagCount,
+                        status
+                );
+            }
         }
 
         Comparator<Question> comparator = getComparator(sortBy, sortOrder);
@@ -228,12 +213,12 @@ public class QuestionServiceImpl implements QuestionService {
         int startIndex = pageNumber * pageSize;
         int endIndex = Math.min(startIndex + pageSize, totalQuestions);
         List<Question> paginatedQuestions = new ArrayList<>();
-        if(startIndex < endIndex){
+        if (startIndex < endIndex) {
             paginatedQuestions = questionList.subList(startIndex, endIndex);
         }
         List<QuestionDTO> questionDTOS = paginatedQuestions.stream()
                 .map(question -> modelMapper.map(question, QuestionDTO.class))
-                .toList();
+                .collect(Collectors.toList());
         QuestionResponse questionResponse = new QuestionResponse();
         questionResponse.setContent(questionDTOS);
         questionResponse.setPageNumber(pageNumber);
@@ -242,7 +227,6 @@ public class QuestionServiceImpl implements QuestionService {
         questionResponse.setTotalPages((int) Math.ceil((double) totalQuestions / pageSize));
         questionResponse.setLastPage(endIndex == totalQuestions);
         return questionResponse;
-
     }
 
     private Comparator<Question> getComparator(String sortBy, String sortOrder) {
@@ -256,32 +240,10 @@ public class QuestionServiceImpl implements QuestionService {
             case "difficulty" -> sortOrder.equalsIgnoreCase("asc") ?
                     Comparator.comparing(Question::getDifficulty) :
                     Comparator.comparing(Question::getDifficulty).reversed();
-            case "questionId" ->
-                    sortOrder.equalsIgnoreCase("asc") ?
-                            Comparator.comparingLong(Question::getQuestionId) :
-                            Comparator.comparingLong(Question::getQuestionId).reversed();
+            case "questionId" -> sortOrder.equalsIgnoreCase("asc") ?
+                    Comparator.comparingLong(Question::getQuestionId) :
+                    Comparator.comparingLong(Question::getQuestionId).reversed();
             default -> null;
         };
     }
-
 }
-
-
-/*   
-Note on Bidirectional Relationships in JPA:
-In a bidirectional relationship, Spring JPA does not automatically
-update the association on both sides. For example, when persisting
-a Question with its Options, the "question" field in the Option entity
-must be explicitly set. This ensures that the foreign key (QUESTION_ID)
-in the options table is populated.
-
-Reason: JPA does not infer the relationship on the inverse (child) side
-unless explicitly mapped in the code. Without setting the relationship
-on both sides, the child entity (Option) won't know about the parent
-entity (Question), resulting in a null foreign key.
-
-Example fix:
-Before saving the Question, ensure each Option has its "question" field set:
-*/
-
-

--- a/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionServiceImpl.java
+++ b/backend_spring/src/main/java/com/example/project_orion/service/impl/QuestionServiceImpl.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.example.project_orion.enums.Status;
+import com.example.project_orion.service.QuestionIdGeneratorService;
 import com.example.project_orion.service.QuestionService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +24,7 @@ import com.example.project_orion.models.Answer;
 import com.example.project_orion.models.Option;
 import com.example.project_orion.models.Question;
 import com.example.project_orion.models.Tag;
+import com.example.project_orion.enums.Status;
 import com.example.project_orion.payload.Filter;
 import com.example.project_orion.payload.dtos.QuestionDTO;
 import com.example.project_orion.payload.responses.QuestionResponse;
@@ -41,6 +42,9 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Autowired
     private ModelMapper modelMapper;
+
+    @Autowired
+    private QuestionIdGeneratorService questionIdGeneratorService;
 
     @Override
     public QuestionResponse getAllQuestions(Integer pageNumber, Integer pageSize, String sortBy, String sortOrder) {
@@ -65,16 +69,6 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
-    public QuestionDTO deleteQuestion(Long questionId) {
-        Question questionFromDB = questionRepository.findById(questionId)
-                .orElseThrow(() -> new ResourceNotFoundException("Question", "questionId", questionId));
-
-        questionRepository.delete(questionFromDB);
-
-        return modelMapper.map(questionFromDB, QuestionDTO.class);
-    }
-
-    @Override
     public QuestionDTO createQuestion(String authorName, QuestionDTO questionDTO) {
         Question questionFromDB = questionRepository.findByTitle(questionDTO.getTitle());
 
@@ -82,7 +76,10 @@ public class QuestionServiceImpl implements QuestionService {
             throw new APIException("Question with title " + questionDTO.getTitle() + " already exists!!!");
         }
 
+        Long generatedId = questionIdGeneratorService.generateNextId();
+
         Question question = Question.builder()
+                .questionId(generatedId)
                 .title(questionDTO.getTitle())
                 .description(questionDTO.getDescription())
                 .author(authorName)
@@ -180,6 +177,16 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    public QuestionDTO deleteQuestion(Long questionId) {
+        Question questionFromDB = questionRepository.findById(questionId)
+                .orElseThrow(() -> new APIException("Question with id " + questionId + " not found!"));
+
+        QuestionDTO questionDTO = modelMapper.map(questionFromDB, QuestionDTO.class);
+        questionRepository.delete(questionFromDB);
+        return questionDTO;
+    }
+
+    @Override
     public QuestionResponse fetchAllQuestions(Filter filter, Integer pageNumber, Integer pageSize, String sortBy, String sortOrder, String userType) {
         String status = "public".equalsIgnoreCase(userType) ? Status.ACTIVE.name() : null;
 
@@ -240,9 +247,10 @@ public class QuestionServiceImpl implements QuestionService {
             case "difficulty" -> sortOrder.equalsIgnoreCase("asc") ?
                     Comparator.comparing(Question::getDifficulty) :
                     Comparator.comparing(Question::getDifficulty).reversed();
-            case "questionId" -> sortOrder.equalsIgnoreCase("asc") ?
-                    Comparator.comparingLong(Question::getQuestionId) :
-                    Comparator.comparingLong(Question::getQuestionId).reversed();
+            case "questionId" ->
+                    sortOrder.equalsIgnoreCase("asc") ?
+                            Comparator.comparingLong(Question::getQuestionId) :
+                            Comparator.comparingLong(Question::getQuestionId).reversed();
             default -> null;
         };
     }


### PR DESCRIPTION

#### **Issue 1: MySQL ID Jump Anomaly**  
- The `id` values for questions in the MySQL database unexpectedly jumped from 2 to 52, causing inconsistencies in data retrieval.  
- This issue extended to answers and options, potentially disrupting foreign key relationships. 

#### **Issue 2: Inactive Questions Being Selected**  
- Inactive questions were appearing in query results, even when they should only be visible to admins.  
- Expected behavior:  
  - **Admins** should see both active and inactive questions.  
  - **Public users** should see only active questions.  